### PR TITLE
Specify branch explicitly in config setup

### DIFF
--- a/docs/neovim-support.md
+++ b/docs/neovim-support.md
@@ -37,6 +37,7 @@ parser_config.cds = {
             -- local path or git repo
             url = "https://github.com/cap-js-community/tree-sitter-cds.git",
             -- url = "/path/to/tree-sitter-cds",
+            branch = "main",
             files = { "src/parser.c", "src/scanner.c" }
       },
       filetype = "cds",


### PR DESCRIPTION
The treesitter installer [assumes `master` branch](https://github.com/nvim-treesitter/nvim-treesitter/blob/master/lua/nvim-treesitter/shell_command_selectors.lua#L234), which causes the installation to fail:

```text
[nvim-treesitter] [0/1] Downloading tree-sitter-cds...
[nvim-treesitter] [0/1] Creating temporary directory
[nvim-treesitter] [0/1] Extracting tree-sitter-cds...
nvim-treesitter[cds]: Failed to execute the following command:
{
  cmd = "mv",
  opts = {
    args = { "-f", "tree-sitter-cds-tmp/tree-sitter-cds-master", "tree-sitter-cds" },
    cwd = "/root/.local/share/nvim",
    stdio = {
      [2] = <userdata 1>,
      [3] = <userdata 2>
    }
  }
}
mv: cannot stat 'tree-sitter-cds-tmp/tree-sitter-cds-master': No such file or directory
```

Need to specify the actual branch `main` explicitly.