### PR TITLE
feat(setup): Lua flavour of auto command to set CDS filetype

### DIFF
--- a/nvim/auto.lua
+++ b/nvim/auto.lua
@@ -1,0 +1,1 @@
+vim.api.nvim_create_autocmd({ 'BufRead', 'BufNewFile' }, { pattern = '*.cds', command = 'set filetype=cds' })


### PR DESCRIPTION
For those (like me) who are aiming for a Lua-only configuration of Neovim, I've added a Lua equivalent of [cds.vim](https://github.com/cap-js-community/tree-sitter-cds/blob/main/nvim/cds.vim).