### PR TITLE
feat(grammar): Introduce unicode identifiers

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1424,7 +1424,7 @@ module.exports = grammar({
       $._delimited_identifier,
     ),
 
-    _unquoted_identifier: $ => /[$_a-zA-Z][$_a-zA-Z0-9]*/,
+    _unquoted_identifier: $ => /[\p{ID_Start}$_][\p{ID_Continue}$\u200C\u200D]*/u,
     _delimited_identifier: $ => token(choice(
       // new style
       /!\[[^\]\n\r\u2028\u2029]*](][^\]\n\r\u2028\u2029]*])*/,

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -10371,7 +10371,7 @@
     },
     "_unquoted_identifier": {
       "type": "PATTERN",
-      "value": "[$_a-zA-Z][$_a-zA-Z0-9]*"
+      "value": "[\\p{ID_Start}$_][\\p{ID_Continue}$\\u200C\\u200D]*"
     },
     "_delimited_identifier": {
       "type": "TOKEN",

--- a/test/corpus/identifiers.txt
+++ b/test/corpus/identifiers.txt
@@ -1,0 +1,34 @@
+================================================================================
+Unicode
+================================================================================
+
+entity Ä {
+   ß : String;
+   _ : _ä;
+   ä_ : $ß;
+   _ä : äöü;
+};
+
+--------------------------------------------------------------------------------
+
+(cds
+  (entity_definition
+    (simple_path
+      (identifier))
+    (element_definitions
+      (element_definition
+        (identifier)
+        (simple_path
+          (identifier)))
+      (element_definition
+        (identifier)
+        (simple_path
+          (identifier)))
+      (element_definition
+        (identifier)
+        (simple_path
+          (identifier)))
+      (element_definition
+        (identifier)
+        (simple_path
+          (identifier))))))


### PR DESCRIPTION
The `@sap/cds-compiler` in version 4.4.0 (2023-11-09) or later added support for Unicode identifiers.  Add it to tree-sitter-cds as well.