### PR TITLE
docs(contributing): Update link to outdated .reuse/dep5

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 
 All members of the project community must abide by the [Contributor Covenant, version 2.1](CODE_OF_CONDUCT.md).
 Only by respecting each other we can develop a productive, collaborative community.
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting [a project maintainer](.reuse/dep5).
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting [a project maintainer](REUSE.toml).
 
 ## Engaging in Our Project
 


### PR DESCRIPTION
Instead, refer to `REUSE.toml`