### PR TITLE
ci: Fix "Workflow does not contain permissions"

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,6 +10,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
Potential fix for [https://github.com/cap-js-community/tree-sitter-cds/security/code-scanning/1](https://github.com/cap-js-community/tree-sitter-cds/security/code-scanning/1)

To fix the issue, we need to explicitly define the permissions for the workflow. Since the workflow primarily reads repository contents and does not perform any write operations, we can set the permissions to `contents: read`. This ensures the workflow has only the minimal access required to complete its tasks.

The changes should be made at the root level of the workflow file to apply to all jobs unless specific jobs require additional permissions. No new dependencies or imports are needed for this fix.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
